### PR TITLE
Update secrets config reference from dev to prd

### DIFF
--- a/tls-pem/doppler-template.yaml
+++ b/tls-pem/doppler-template.yaml
@@ -6,7 +6,7 @@ projects:
         configs:
           - slug: 'prd'
     secrets:
-      dev:
+      prd:
         APP_PORT: '8080'
         APP_API_KEY: 'c390b68c-f66d-4a78-89c5-5502fc56174b'
         APP_DB_URL: postgres://app:secret@db-dev:5432/app-db


### PR DESCRIPTION
It looks like the environment was changed from `dev` to `prd` 8 months ago, but the secret reference to the environment was still referencing `dev`.